### PR TITLE
Fix warning on non-Windows systems

### DIFF
--- a/src/Commands/SiteMountCommand.php
+++ b/src/Commands/SiteMountCommand.php
@@ -12,7 +12,7 @@ use Pantheon\Terminus\Collections\Sites;
 define('HOME', getenv('HOME'));
 
 // Determine the default mount location.
-$temp_dir = WINDOWS ? '\\Temp' : '/tmp';
+$temp_dir = defined('WINDOWS') ? '\\Temp' : '/tmp';
 define('TEMP_DIR', $temp_dir);
 
 /**


### PR DESCRIPTION
Referencing the constant `WINDOWS` prints an warning on systems where it is not defined.